### PR TITLE
Add recursive generation of go nix packages

### DIFF
--- a/gen/go.mod
+++ b/gen/go.mod
@@ -1,3 +1,5 @@
 module github.com/katexochen/gobuild.nix/gen
 
 go 1.24.1
+
+require golang.org/x/mod v0.24.0

--- a/gen/go.mod
+++ b/gen/go.mod
@@ -3,3 +3,9 @@ module github.com/katexochen/gobuild.nix/gen
 go 1.24.1
 
 require golang.org/x/mod v0.24.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.9.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/gen/go.mod
+++ b/gen/go.mod
@@ -1,0 +1,3 @@
+module github.com/katexochen/gobuild.nix/gen
+
+go 1.24.1

--- a/gen/go.sum
+++ b/gen/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=

--- a/gen/go.sum
+++ b/gen/go.sum
@@ -1,2 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
 golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/gen/main.go
+++ b/gen/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+const goPkgsPath = "go-packages"
+
+func main() {
+	importPath, version, ok := strings.Cut(os.Args[1], "@")
+	if !ok {
+		log.Fatalf("Invalid import path format: %q. Expected 'pname@version'", os.Args[1])
+	}
+	if _, err := os.Stat(path.Join(goPkgsPath, importPath)); err == nil {
+		return
+	}
+
+	output, err := fetch(importPath, version)
+	if err != nil {
+		log.Fatalf("Error prefetching %q: %v", os.Args[1], err)
+	}
+	log.Printf("Output %s", output)
+}
+
+func fetch(importPath, version string) (string, error) {
+	cmd := exec.Command("nix-prefetch-url", "--print-path", "--unpack", fmt.Sprintf("https://%s/archive/refs/tags/%s.tar.gz", importPath, version))
+	output, err := cmd.Output()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return "", fmt.Errorf("executing nix-prefetch-url: %s", exitErr.Stderr)
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}

--- a/gen/main.go
+++ b/gen/main.go
@@ -121,6 +121,10 @@ func Package(importPath, version string, override bool) error {
 
 	log.Printf("Packaged %s@%s\n", importPath, version)
 
+	// If there's no modfile we can't recurse into the dependencies.
+	if modFile == nil {
+		return nil
+	}
 	var deps []*modfile.Require
 	for _, r := range modFile.Require {
 		if r.Indirect {

--- a/gen/main.go
+++ b/gen/main.go
@@ -110,7 +110,8 @@ func Package(importPath, version string, override bool) error {
 	if err := os.MkdirAll(filepath.Join(goPkgsPath, importPath), 0o755); err != nil {
 		return fmt.Errorf("creating go-packages directory: %w", err)
 	}
-	f, err := os.OpenFile(filepath.Join(goPkgsPath, importPath, "package.nix"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	outputPath := filepath.Join(goPkgsPath, importPath, "package.nix")
+	f, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("creating go-packages file: %w", err)
 	}
@@ -119,7 +120,7 @@ func Package(importPath, version string, override bool) error {
 		return fmt.Errorf("writing go-packages file: %w", err)
 	}
 
-	log.Printf("Packaged %s@%s\n", importPath, version)
+	log.Printf("Generated %s", outputPath)
 
 	// If there's no modfile we can't recurse into the dependencies.
 	if modFile == nil {

--- a/gen/main.go
+++ b/gen/main.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
+
+	"golang.org/x/mod/modfile"
 )
 
 const goPkgsPath = "go-packages"
@@ -17,49 +21,205 @@ func main() {
 	if !ok {
 		log.Fatalf("Invalid import path format: %q. Expected 'pname@version'", os.Args[1])
 	}
-	if _, err := os.Stat(path.Join(goPkgsPath, importPath)); err == nil {
-		return
-	}
+	// if _, err := os.Stat(path.Join(goPkgsPath, importPath)); err == nil {
+	// 	return
+	// }
 
-	hash, storePath, err := fetch(importPath, version)
+	src, err := FetchFromGitHubFromImportpath(importPath)
+	if err != nil {
+		log.Fatalf("Error creating src from import path: %v", err)
+	}
+	src.Tag = version
+	version = strings.TrimPrefix(version, "v")
+
+	src.Hash, src.storePath, err = fetch(src)
 	if err != nil {
 		log.Fatalf("Error prefetching %q: %v", os.Args[1], err)
 	}
 
+	modFile, err := readMod(path.Join(src.storePath, "go.mod"))
+	if err != nil {
+		log.Fatalf("Error reading go.mod: %v", err)
+	}
+
+	var directRequires []string
+	for _, r := range modFile.Require {
+		if r.Indirect {
+			continue
+		}
+		directRequires = append(directRequires, fmt.Sprintf("goPackages.%q", r.Mod.Path))
+	}
+
 	pkg := Pkg{
+		Imports: []string{
+			"fetchFromGitHub",
+			"stdenv",
+			"goPackages",
+		},
 		ImportPath: importPath,
 		Version:    version,
-		Source:     Source{StorePath: storePath, Hash: hash},
+		Source:     src,
+		NativeBuildInputs: []string{
+			"goPackages.hooks.makeGoDependency",
+		},
+		PropagatedBuildInputs: directRequires,
 	}
-	log.Printf("Pkg: %s", pkg)
+	out, err := pkg.MarshalText()
+	if err != nil {
+		log.Fatalf("Error marshaling src: %v", err)
+	}
+	out = nixfmt(out)
+
+	if err := os.MkdirAll(importPath, 0o755); err != nil {
+		log.Fatalf("Error creating go-packages directory: %v", err)
+	}
+	f, err := os.OpenFile(filepath.Join(goPkgsPath, importPath, "package.nix"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		log.Fatalf("Error creating go-packages file: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(out); err != nil {
+		log.Fatalf("Error writing go-packages file: %v", err)
+	}
 }
 
 type Pkg struct {
-	ImportPath string
-	Version    string
-	Source     Source
+	Imports               []string
+	ImportPath            string
+	Version               string
+	Source                FetchFromGitHub
+	NativeBuildInputs     []string
+	PropagatedBuildInputs []string
 }
 
-type Source struct {
-	StorePath string
-	Hash      string
+func (p Pkg) MarshalText() ([]byte, error) {
+	b := strings.Builder{}
+	b.WriteString("{\n")
+	for _, imp := range p.Imports {
+		b.WriteString(fmt.Sprintf("%s,\n", imp))
+	}
+	b.WriteString("}:\n\n")
+	b.WriteString("stdenv.mkDerivation (finalAttrs: {\n")
+	b.WriteString(fmt.Sprintf("pname = %q;\n", p.ImportPath))
+	b.WriteString(fmt.Sprintf("version = %q;\n", p.Version))
+	src, err := p.Source.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	b.WriteString(fmt.Sprintf("\nsrc = %s;\n\n", src))
+	b.WriteString("nativeBuildInputs = [\n")
+	for _, nbi := range p.NativeBuildInputs {
+		b.WriteString(fmt.Sprintf("%s\n", nbi))
+	}
+	b.WriteString("];\n\n")
+	if len(p.PropagatedBuildInputs) > 0 {
+		b.WriteString("propagatedBuildInputs = [\n")
+		for _, pbi := range p.PropagatedBuildInputs {
+			b.WriteString(fmt.Sprintf("%s\n", pbi))
+		}
+		b.WriteString("];\n\n")
+	}
+	b.WriteString("})")
+	return []byte(b.String()), nil
 }
 
-func fetch(importPath, version string) (hash, storePath string, retErr error) {
-	cmd := exec.Command("nix-prefetch-url", "--print-path", "--unpack", fmt.Sprintf("https://%s/archive/refs/tags/%s.tar.gz", importPath, version))
+type FetchFromGitHub struct {
+	Owner string
+	Repo  string
+	Rev   string
+	Tag   string
+	Hash  string
+
+	storePath string
+}
+
+func FetchFromGitHubFromImportpath(importPath string) (FetchFromGitHub, error) {
+	parts := strings.Split(importPath, "/")
+	if len(parts) != 3 {
+		log.Fatalf("Invalid import path: %q. Expected 'github.com/owner/repo'", importPath)
+	}
+	return FetchFromGitHub{
+		Owner: parts[1],
+		Repo:  parts[2],
+	}, nil
+}
+
+func (f FetchFromGitHub) MarshalText() ([]byte, error) {
+	b := strings.Builder{}
+	b.WriteString("fetchFromGitHub {\n")
+	b.WriteString(fmt.Sprintf("owner = %q;\n", f.Owner))
+	b.WriteString(fmt.Sprintf("repo = %q;\n", f.Repo))
+	if f.Tag != "" {
+		b.WriteString("tag = \"v${finalAttrs.version}\";\n")
+	} else {
+		b.WriteString(fmt.Sprintf("rev = %q;\n", f.Rev))
+	}
+	b.WriteString(fmt.Sprintf("hash = %q;\n", f.Hash))
+	b.WriteString("}")
+	return []byte(b.String()), nil
+}
+
+func (f FetchFromGitHub) URL() string {
+	rev := f.Tag
+	if rev == "" {
+		rev = f.Rev
+	}
+	return fmt.Sprintf("https://github.com/%s/%s/archive/%s.tar.gz", f.Owner, f.Repo, rev)
+}
+
+type URLer interface {
+	URL() string
+}
+
+func fetch(urler URLer) (hash, storePath string, retErr error) {
+	cmd := exec.Command("nix-prefetch-url", "--print-path", "--unpack", urler.URL())
 	output, err := cmd.Output()
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		return "", "", fmt.Errorf("executing nix-prefetch-url: %s", exitErr.Stderr)
-	}
-	if err != nil {
+	} else if err != nil {
 		return "", "", err
 	}
 
 	hash, storePath, ok := strings.Cut(string(output), "\n")
 	if !ok {
-		return "", "", fmt.Errorf("splitting nix-prefetch-url output:", string(output))
+		return "", "", fmt.Errorf("splitting nix-prefetch-url output: %s", string(output))
+	}
+	storePath = strings.TrimSpace(storePath)
+
+	cmd = exec.Command("nix-hash", "--sri", "--type", "sha256", storePath)
+	sriHash, err := cmd.Output()
+	if errors.As(err, &exitErr) {
+		return "", "", fmt.Errorf("executing nix-hash: %s", exitErr.Stderr)
+	} else if err != nil {
+		return "", "", err
 	}
 
-	return hash, storePath, nil
+	return strings.TrimSpace(string(sriHash)), storePath, nil
+}
+
+func nixfmt(b []byte) []byte {
+	cmd := exec.Command("nixfmt")
+	cmd.Stdin = bytes.NewBuffer(b)
+	out, err := cmd.Output()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		log.Fatalf("Error formatting nix: %s", exitErr.Stderr)
+	} else if err != nil {
+		log.Fatalf("Error formatting nix: %v", err)
+	}
+	return out
+}
+
+func readMod(modpath string) (*modfile.File, error) {
+	modBytes, err := os.ReadFile(modpath)
+	if err != nil {
+		return nil, err
+	}
+
+	mod, err := modfile.Parse("go.mod", modBytes, nil)
+	if err != nil {
+		return nil, err
+	}
+	return mod, nil
 }

--- a/go-packages/github.com/rogpeppe/go-internal/package.nix
+++ b/go-packages/github.com/rogpeppe/go-internal/package.nix
@@ -1,12 +1,25 @@
-{ mkGoModule, goPackages }:
+{
+  stdenv,
+  fetchFromGitHub,
+  goPackages,
+}:
 
-mkGoModule {
+stdenv.mkDerivation (finalAttrs: {
   pname = "github.com/rogpeppe/go-internal";
   version = "1.13.1";
-  hash = "sha256-fD4n3XVDNHL7hfUXK9qi31LpBVzWnRK/7LNc3BmPtnU=";
-  buildInputs = [
+
+  src = fetchFromGitHub {
+    owner = "rogpeppe";
+    repo = "go-internal";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fD4n3XVDNHL7hfUXK9qi31LpBVzWnRK/7LNc3BmPtnU=";
+  };
+
+  nativeBuildInputs = [ goPackages.hooks.makeGoDependency ];
+
+  propagatedBuildInputs = [
     goPackages."golang.org/x/mod"
     goPackages."golang.org/x/sys"
     goPackages."golang.org/x/tools"
   ];
-}
+})

--- a/shell.nix
+++ b/shell.nix
@@ -20,6 +20,7 @@ pkgs.mkShell {
   packages = [
     goPackages.go
     cacher
+    pkgs.nixfmt-rfc-style
   ];
 
   env = {


### PR DESCRIPTION
- **Start writing a nix package generator for Go packages**
- **Define a struct representing nix package to generate**
- **refactor to not use build helper**
- **generate nix code**
- **Introduce override flag using cobra CLI**
- **recursive packaging**
- **Return early for modules that don't have a mod file**
- **Output the path to the generated file**
- **Log which module we're about to package before parsing the version**
- **Return explicit error in case of pseudo versions**
- **Improve version matching to catch more cases**
